### PR TITLE
exclude generated XS files from dist

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -32,6 +32,10 @@
 \bBUILD.COM$
 \bbuild.com$
 
+# avoid XS generated files
+\.bs$
+\.[oc]$
+
 # and Module::Build::Tiny generated files
 \b_build_params$
 


### PR DESCRIPTION
Previous changes to MANIFEST.SKIP accidentally removed the exclusions
for o, c, and bs files which are generated during compilation.